### PR TITLE
Update default Knative version to 0.26

### DIFF
--- a/automation/infrastructure/terraform/kcs/install_knative/variables.tf
+++ b/automation/infrastructure/terraform/kcs/install_knative/variables.tf
@@ -47,5 +47,5 @@ variable "kubeconfig_filename" {
 variable "knative_version" {
   type        = string
   description = "version of knative"
-  default     = "0.25.0"
+  default     = "0.26.0"
 }


### PR DESCRIPTION
[Knative v0.26 is out](https://knative.dev/blog/2021/10/04/v0.26-release/). Updating default knative_version terraform variable.