### PR TITLE
Update kubeflow_version default value in kubeflow terraform

### DIFF
--- a/automation/infrastructure/terraform/kcs/install_kubeflow/variables.tf
+++ b/automation/infrastructure/terraform/kcs/install_kubeflow/variables.tf
@@ -47,5 +47,5 @@ variable "kubeconfig_filename" {
 variable "kubeflow_version" {
   type        = string
   description = "version of kubeflow"
-  default     = "1.3.0"
+  default     = "1.4.0"
 }


### PR DESCRIPTION
Update default `kubeflow_version` value from 1.3.0 to 1.4.0